### PR TITLE
Add the website for MarseilleJS

### DIFF
--- a/groupes.html
+++ b/groupes.html
@@ -5,68 +5,68 @@ title: Groupes
 <article>
   <h2>Les groupes locaux</h2>
   <p><strong>Ceci est une liste des groupes locaux que nous avons identifiés, leur statut, leurs outils de communication et leur position vis-à-vis de FranceJS.</strong></p>
-	<p>En cas d'erreur, d'ajout de membre ou de précision vous pouvez <em>forker</em> <a href="https://github.com/francejs/francejs.github.com" title="Voir le dépôt">le dépôt Git</a> et soumettre un pull request ou simplement <a href="https://github.com/francejs/francejs.github.com/issues" title="Envoyer une remarque">poster une issue</a>.</p>
+  <p>En cas d'erreur, d'ajout de membre ou de précision vous pouvez <em>forker</em> <a href="https://github.com/francejs/francejs.github.com" title="Voir le dépôt">le dépôt Git</a> et soumettre un pull request ou simplement <a href="https://github.com/francejs/francejs.github.com/issues" title="Envoyer une remarque">poster une issue</a>.</p>
 
-	<ul>
-		<li><a href="#paris-js" title="Naviguer vers la section">Paris.js</a></li>
+  <ul>
+    <li><a href="#paris-js" title="Naviguer vers la section">Paris.js</a></li>
     <li><a href="#lyon-js" title="Naviguer vers la section">LyonJS</a></li>
-		<li><a href="#nantes-js" title="Naviguer vers la section">NantesJS</a></li>
-		<li><a href="#toulouse-js" title="Naviguer vers la section">ToulouseJS</a></li>
-		<li><a href="#bordeaux-js" title="Naviguer vers la section">BordeauxJS</a></li>
-		<li><a href="#nord-js" title="Naviguer vers la section">NordJS</a></li>
-		<li><a href="#marseille-js" title="Naviguer vers la section">MarseilleJS</a></li>
-		<li><a href="#caen-js" title="Naviguer vers la section">CaenJS</a></li>
+    <li><a href="#nantes-js" title="Naviguer vers la section">NantesJS</a></li>
+    <li><a href="#toulouse-js" title="Naviguer vers la section">ToulouseJS</a></li>
+    <li><a href="#bordeaux-js" title="Naviguer vers la section">BordeauxJS</a></li>
+    <li><a href="#nord-js" title="Naviguer vers la section">NordJS</a></li>
+    <li><a href="#marseille-js" title="Naviguer vers la section">MarseilleJS</a></li>
+    <li><a href="#caen-js" title="Naviguer vers la section">CaenJS</a></li>
     <li><a href="#js-sophia" title="Naviguer vers la section">JSSophia</a></li>
-		<li><a href="#rennes-js" title="Naviguer vers la section">RennesJS</a></li>
-	</ul>
+    <li><a href="#rennes-js" title="Naviguer vers la section">RennesJS</a></li>
+  </ul>
 
   <hr />
 
   <h3 id="paris-js">Paris.js</h3>
   <h4>Statut</h4>
-	<p>Groupe informel constitué autour de JavaScript.</p>
-	<h4>Médias</h4>
-	<ul>
-		<li>Site <a href="http://parisjs.org/" title="Voir le site">ParisJS.org</a></li>
-		<li>Compte Twitter <a href="https://twitter.com/ParisJS" title="Voir le compte Twitter">@ParisJS</a></li>
-		<li>Compte GitHub <a href="https://github.com/parisjs" title="Voir le compte GitHub">ParisJS</a></li>
-		<li>Liste <a href="https://groups.google.com/forum/?fromgroups#!forum/parisjs" title="Voir le forum Google Group">ParisJS</a></li>
-		<li>Canal IRC <a href="irc://irc.freenode.net/#parisjs" title="Rejoindre le canal IRC">#parisjs</a></li>
-	</ul>
-	<h4>Membres</h4>
-	<ul>
-		<li><a href="https://twitter.com/romainhuet" title="Voir son compte Twitter">Romain Huet</a></li>
-		<li><a href="https://twitter.com/tbassetto" title="Voir son compte Twitter">Thomas Bassetto</a></li>
-		<li><a href="https://twitter.com/francois2metz" title="Voir son compte Twitter">François 2 Metz</a></li>
-		<li><a href="https://twitter.com/_kud" title="Voir son compte Twitter">Erwann Mest</a></li>
-	</ul>
-	<h4>Position vis à vis de FranceJS</h4>
+  <p>Groupe informel constitué autour de JavaScript.</p>
+  <h4>Médias</h4>
+  <ul>
+    <li>Site <a href="http://parisjs.org/" title="Voir le site">ParisJS.org</a></li>
+    <li>Compte Twitter <a href="https://twitter.com/ParisJS" title="Voir le compte Twitter">@ParisJS</a></li>
+    <li>Compte GitHub <a href="https://github.com/parisjs" title="Voir le compte GitHub">ParisJS</a></li>
+    <li>Liste <a href="https://groups.google.com/forum/?fromgroups#!forum/parisjs" title="Voir le forum Google Group">ParisJS</a></li>
+    <li>Canal IRC <a href="irc://irc.freenode.net/#parisjs" title="Rejoindre le canal IRC">#parisjs</a></li>
+  </ul>
+  <h4>Membres</h4>
+  <ul>
+    <li><a href="https://twitter.com/romainhuet" title="Voir son compte Twitter">Romain Huet</a></li>
+    <li><a href="https://twitter.com/tbassetto" title="Voir son compte Twitter">Thomas Bassetto</a></li>
+    <li><a href="https://twitter.com/francois2metz" title="Voir son compte Twitter">François 2 Metz</a></li>
+    <li><a href="https://twitter.com/_kud" title="Voir son compte Twitter">Erwann Mest</a></li>
+  </ul>
+  <h4>Position vis à vis de FranceJS</h4>
   <p>Pas contre, à officialiser.</p>
 
   <hr />
 
   <h3 id="lyon-js">LyonJS</h3>
   <h4>Statut</h4>
-	<p>Association</p>
-	<p>L'association sert à donner un statut au petit peu d'argent des sponsors</p>
-	<h4>Médias</h4>
-	<ul>
-		<li>Site <a href="http://lyonjs.org/" title="Voir le site">LyonJS.org</a></li>
-		<li>Compte Twitter <a href="https://twitter.com/LyonJS" title="Voir le compte Twitter">@LyonJS</a></li>
-		<li>Compte GitHub <a href="https://github.com/LyonJS" title="Voir le compte GitHub">LyonJS</a></li>
-	</ul>
-	<h4>Membres</h4>
-	<ul>
-		<li><a href="https://twitter.com/Filirom1" title="Voir son compte Twitter">Romain Philibert</a></li>
-		<li><a href="https://twitter.com/louis_remi" title="Voir son compte Twitter">Louis-Rémi Badé</a></li>
-		<li><a href="https://twitter.com/temsa" title="Voir son compte Twitter">Florian Traverse</a></li>
-		<li><a href="https://twitter.com/maxired" title="Voir son compte Twitter">Maxence Dalmais</a></li>
-		<li><a href="https://twitter.com/" title="Voir son compte Twitter">Nicolas Morel</a></li>
-		<li><a href="https://twitter.com/Swiip" title="Voir son compte Twitter">Matthieu Lux</a></li>
-		<li><a href="https://twitter.com/naholyr" title="Voir son compte Twitter">Nicolas Chambrier</a></li>
-		<li><a href="https://twitter.com/mklabs" title="Voir son compte Twitter">Mickael Daniel (a déménagé à Grenoble)</a></li>
-	</ul>
-	<h4>Position vis à vis de FranceJS</h4>
+  <p>Association</p>
+  <p>L'association sert à donner un statut au petit peu d'argent des sponsors</p>
+  <h4>Médias</h4>
+  <ul>
+    <li>Site <a href="http://lyonjs.org/" title="Voir le site">LyonJS.org</a></li>
+    <li>Compte Twitter <a href="https://twitter.com/LyonJS" title="Voir le compte Twitter">@LyonJS</a></li>
+    <li>Compte GitHub <a href="https://github.com/LyonJS" title="Voir le compte GitHub">LyonJS</a></li>
+  </ul>
+  <h4>Membres</h4>
+  <ul>
+    <li><a href="https://twitter.com/Filirom1" title="Voir son compte Twitter">Romain Philibert</a></li>
+    <li><a href="https://twitter.com/louis_remi" title="Voir son compte Twitter">Louis-Rémi Badé</a></li>
+    <li><a href="https://twitter.com/temsa" title="Voir son compte Twitter">Florian Traverse</a></li>
+    <li><a href="https://twitter.com/maxired" title="Voir son compte Twitter">Maxence Dalmais</a></li>
+    <li><a href="https://twitter.com/" title="Voir son compte Twitter">Nicolas Morel</a></li>
+    <li><a href="https://twitter.com/Swiip" title="Voir son compte Twitter">Matthieu Lux</a></li>
+    <li><a href="https://twitter.com/naholyr" title="Voir son compte Twitter">Nicolas Chambrier</a></li>
+    <li><a href="https://twitter.com/mklabs" title="Voir son compte Twitter">Mickael Daniel (a déménagé à Grenoble)</a></li>
+  </ul>
+  <h4>Position vis à vis de FranceJS</h4>
   <p>Pas contre, à officialiser.</p>
 
   <hr />
@@ -94,72 +94,72 @@ title: Groupes
 
   <h3 id="toulouse-js">ToulouseJS</h3>
   <h4>Statut</h4>
-	<p>Groupe informel constitué autour de JavaScript.</p>
-	<h4>Médias</h4>
-	<ul>
-		<li>Site <a href="http://toulousejs.org/" title="Voir le site">ToulouseJS.org</a></li>
-		<li>Compte Twitter <a href="https://twitter.com/ToulouseJS" title="Voir le compte Twitter">@ToulouseJS</a></li>
-	</ul>
-	<h4>Membres</h4>
-	<ul>
-		<li><a href="https://twitter.com/Atinux" title="Voir son compte Twitter">Sébastien Chopin</a> (fondateur)</li>
-		<li><a href="https://twitter.com/goldoraf" title="Voir son compte Twitter">Raphaël Rougeron</a></li>
-	</ul>
-	<h4>Position vis à vis de FranceJS</h4>
+  <p>Groupe informel constitué autour de JavaScript.</p>
+  <h4>Médias</h4>
+  <ul>
+    <li>Site <a href="http://toulousejs.org/" title="Voir le site">ToulouseJS.org</a></li>
+    <li>Compte Twitter <a href="https://twitter.com/ToulouseJS" title="Voir le compte Twitter">@ToulouseJS</a></li>
+  </ul>
+  <h4>Membres</h4>
+  <ul>
+    <li><a href="https://twitter.com/Atinux" title="Voir son compte Twitter">Sébastien Chopin</a> (fondateur)</li>
+    <li><a href="https://twitter.com/goldoraf" title="Voir son compte Twitter">Raphaël Rougeron</a></li>
+  </ul>
+  <h4>Position vis à vis de FranceJS</h4>
   <p>Pas d'information.</p>
 
   <hr />
 
   <h3 id="bordeaux-js">BordeauxJS</h3>
   <h4>Statut</h4>
-	<p>Groupe informel constitué autour de JavaScript.</p>
-	<h4>Médias</h4>
-	<ul>
-		<li>Site <a href="http://www.meetup.com/BordeauxJS/" title="Voir le site">BordeauxJS sur Meetup.com</a></li>
-		<li>Compte Twitter <a href="https://twitter.com/BordeauxJS" title="Voir le compte Twitter">@BordeauxJS</a></li>
-	</ul>
-	<h4>Membres</h4>
-	<ul>
-		<li><a href="https://twitter.com/oncletom" title="Voir son compte Twitter">Thomas Parisot</a> (fondateur)</li>
-	</ul>
-	<h4>Position vis à vis de FranceJS</h4>
+  <p>Groupe informel constitué autour de JavaScript.</p>
+  <h4>Médias</h4>
+  <ul>
+    <li>Site <a href="http://www.meetup.com/BordeauxJS/" title="Voir le site">BordeauxJS sur Meetup.com</a></li>
+    <li>Compte Twitter <a href="https://twitter.com/BordeauxJS" title="Voir le compte Twitter">@BordeauxJS</a></li>
+  </ul>
+  <h4>Membres</h4>
+  <ul>
+    <li><a href="https://twitter.com/oncletom" title="Voir son compte Twitter">Thomas Parisot</a> (fondateur)</li>
+  </ul>
+  <h4>Position vis à vis de FranceJS</h4>
   <p>Pas contre, à officialiser.</p>
 
   <hr />
 
   <h3 id="nord-js">NordJS / LilleJS</h3>
   <h4>Statut</h4>
-	<p>Groupe informel en cours de constitution autour de JavaScript.</p>
-	<h4>Médias</h4>
-	<ul>
-		<li>Liste <a href="https://groups.google.com/forum/?fromgroups#!forum/nordjs" title="Voir le forum Google Group">NordJS</a></li>
-	</ul>
-	<h4>Membres</h4>
-	<ul>
-		<li><a href="https://twitter.com/_fuse" title="Voir son compte Twitter">Martin Catty</a> (fondateur)</li>
-		<li><a href="https://twitter.com/remi_grumeau" title="Voir son compte Twitter">Remi Grumeau</a> (fondateur)</li>
-		<li><a href="https://twitter.com/_flexbox" title="Voir son compte Twitter">David Leuliette</a> (fondateur)</li>
-		<li><a href="https://twitter.com/rbwebdev" title="Voir son compte Twitter">Romain Brasier</a> (fondateur)</li>
-		<li><a href="https://twitter.com/nfroidure" title="Voir son compte Twitter">Nicolas Froidure</a> (fondateur)</li>
-	</ul>
-	<h4>Position vis à vis de FranceJS</h4>
+  <p>Groupe informel en cours de constitution autour de JavaScript.</p>
+  <h4>Médias</h4>
+  <ul>
+    <li>Liste <a href="https://groups.google.com/forum/?fromgroups#!forum/nordjs" title="Voir le forum Google Group">NordJS</a></li>
+  </ul>
+  <h4>Membres</h4>
+  <ul>
+    <li><a href="https://twitter.com/_fuse" title="Voir son compte Twitter">Martin Catty</a> (fondateur)</li>
+    <li><a href="https://twitter.com/remi_grumeau" title="Voir son compte Twitter">Remi Grumeau</a> (fondateur)</li>
+    <li><a href="https://twitter.com/_flexbox" title="Voir son compte Twitter">David Leuliette</a> (fondateur)</li>
+    <li><a href="https://twitter.com/rbwebdev" title="Voir son compte Twitter">Romain Brasier</a> (fondateur)</li>
+    <li><a href="https://twitter.com/nfroidure" title="Voir son compte Twitter">Nicolas Froidure</a> (fondateur)</li>
+  </ul>
+  <h4>Position vis à vis de FranceJS</h4>
   <p>On aime et on en redemande.</p>
 
   <hr />
 
   <h3 id="marseille-js">MarseilleJS</h3>
   <h4>Statut</h4>
-	<p>Groupe informel en cours de constitution autour de JavaScript.</p>
-	<h4>Médias</h4>
-	<ul>
+  <p>Groupe informel en cours de constitution autour de JavaScript.</p>
+  <h4>Médias</h4>
+  <ul>
     <li>Site <a href="http://francejs.org/MarseilleJS/" title="Voir le site">francejs.org/MarseilleJS/</a></li>
-		<li>Compte Twitter <a href="https://twitter.com/MarseilleJS" title="Voir le compte Twitter">@MarseilleJS</a></li>
-	</ul>
-	<h4>Membres</h4>
-	<ul>
-		<li><a href="https://twitter.com/madx" title="Voir son compte Twitter">François Vaux</a> (fondateur)</li>
-	</ul>
-	<h4>Position vis à vis de FranceJS</h4>
+    <li>Compte Twitter <a href="https://twitter.com/MarseilleJS" title="Voir le compte Twitter">@MarseilleJS</a></li>
+  </ul>
+  <h4>Membres</h4>
+  <ul>
+    <li><a href="https://twitter.com/madx" title="Voir son compte Twitter">François Vaux</a> (fondateur)</li>
+  </ul>
+  <h4>Position vis à vis de FranceJS</h4>
 
   <p>On aime et on en redemande.</p>
 
@@ -167,36 +167,36 @@ title: Groupes
 
   <h3 id="caen-js">CaenJS</h3>
   <h4>Statut</h4>
-	<p>Groupe informel en cours de constitution autour de JavaScript.</p>
-	<h4>Médias</h4>
-	<ul>
-		<li>Compte Twitter <a href="https://twitter.com/CaenJS" title="Voir le compte Twitter">@CaenJS</a></li>
-	</ul>
-	<h4>Membres</h4>
-	<ul>
-		<li><a href="https://twitter.com/sylzys" title="Voir son compte Twitter">Sylvain Zyssman</a> (fondateur)</li>
-		<li><a href="https://twitter.com/wleloutre" title="Voir son compte Twitter">Willy Leloutre</a> (fondateur)</li>
-	</ul>
-	<h4>Position vis à vis de FranceJS</h4>
+  <p>Groupe informel en cours de constitution autour de JavaScript.</p>
+  <h4>Médias</h4>
+  <ul>
+    <li>Compte Twitter <a href="https://twitter.com/CaenJS" title="Voir le compte Twitter">@CaenJS</a></li>
+  </ul>
+  <h4>Membres</h4>
+  <ul>
+    <li><a href="https://twitter.com/sylzys" title="Voir son compte Twitter">Sylvain Zyssman</a> (fondateur)</li>
+    <li><a href="https://twitter.com/wleloutre" title="Voir son compte Twitter">Willy Leloutre</a> (fondateur)</li>
+  </ul>
+  <h4>Position vis à vis de FranceJS</h4>
   <p>Pas d'information.</p>
 
   <hr />
 
   <h3 id="js-sophia">JSSophia</h3>
   <h4>Statut</h4>
-	<p>Groupe informel constitué autour de JavaScript.</p>
-	<h4>Médias</h4>
-	<ul>
-		<li>Compte Twitter <a href="https://twitter.com/JSSophia" title="Voir le compte Twitter">@JSSophia</a></li>
-		<li>Mailing List <a href="http://groups.google.com/group/jssophia" title="Voir la Mailing List">JSSophia</a></li>
-		<li>Compte GitHub <a href="https://github.com/jssophia" title="Voir le compte GitHub">JSSophia</a></li>
-	</ul>
-	<h4>Membres</h4>
-	<ul>
-		<li><a href="https://twitter.com/_dhar" title="Voir son compte Twitter">Olivier Audard</a> (fondateur)</li>
-		<li><a href="https://twitter.com/fredguillaume">Frédéric Guillaume</a> (fondateur)</li>
-	</ul>
-	<h4>Position vis à vis de FranceJS</h4>
+  <p>Groupe informel constitué autour de JavaScript.</p>
+  <h4>Médias</h4>
+  <ul>
+    <li>Compte Twitter <a href="https://twitter.com/JSSophia" title="Voir le compte Twitter">@JSSophia</a></li>
+    <li>Mailing List <a href="http://groups.google.com/group/jssophia" title="Voir la Mailing List">JSSophia</a></li>
+    <li>Compte GitHub <a href="https://github.com/jssophia" title="Voir le compte GitHub">JSSophia</a></li>
+  </ul>
+  <h4>Membres</h4>
+  <ul>
+    <li><a href="https://twitter.com/_dhar" title="Voir son compte Twitter">Olivier Audard</a> (fondateur)</li>
+    <li><a href="https://twitter.com/fredguillaume">Frédéric Guillaume</a> (fondateur)</li>
+  </ul>
+  <h4>Position vis à vis de FranceJS</h4>
   <p>Carrément enthousiaste, à officialiser.</p>
 
   <hr />


### PR DESCRIPTION
This PR adds the URL for the website of MarseilleJS in the groupes.html page.

It also removes a lot of tabs, replacing them with spaces, because tabs are ugly :)
