### PR TITLE
remove Erwann Mest from Paris.js members

### DIFF
--- a/groupes.html
+++ b/groupes.html
@@ -38,7 +38,6 @@ title: Groupes
     <li><a href="https://twitter.com/romainhuet" title="Voir son compte Twitter">Romain Huet</a></li>
     <li><a href="https://twitter.com/tbassetto" title="Voir son compte Twitter">Thomas Bassetto</a></li>
     <li><a href="https://twitter.com/francois2metz" title="Voir son compte Twitter">François 2 Metz</a></li>
-    <li><a href="https://twitter.com/_kud" title="Voir son compte Twitter">Erwann Mest</a></li>
   </ul>
   <h4>Position vis à vis de FranceJS</h4>
   <p>Pas contre, à officialiser.</p>


### PR DESCRIPTION
Mr. Mest has nothing to do here. Other suggested changes (not up to me to chose) could be :
- remove the Paris.js list members, since there is no official members in Paris.js
- explicitly write that "Paris.js est auto-organisé via la mailing-list"

see also https://groups.google.com/forum/#!topic/francejs/2yD3BfEi8dQ
