### PR TITLE
Annonce de la conférence FranceJS à Toulouse

### DIFF
--- a/conf2013.html
+++ b/conf2013.html
@@ -1,0 +1,23 @@
+---
+layout: default
+title: Conférence 2013
+---
+<article>
+  <h2>Première conférence FranceJS à Toulouse !</h2>
+  <p><strong>La communauté FranceJS organise sa première conférence à l'occasion du <a href="http://2013.capitoledulibre.org/">Capitole du Libre</a>, les 23 et 24 novembre 2013 à Toulouse.</strong></p>
+  <p>Le samedi sera une journée réservée aux conférences, d'une durée de 40 minutes chacune. La journée de dimanche sera quant à elle dédiée aux ateliers (1h30 et + si nécessaire) et aux Lightning Talks (5 minutes). L'entrée sera gratuite et les inscriptions seront ouvertes courant septembre.</p>
+  <p>L'appel à conférenciers est <a href="https://docs.google.com/forms/d/16SmZSiP0yMfpoD2qDY6g9xL5xF7i11KE1H7pwJ3fZqI/viewform">ouvert</a> jusqu'au 15 septembre, et le programme final sera publié autour du 15 octobre. Nous souhaitons voir aborder toutes les facettes de l'écosystème JavaScript, aussi les thèmes possibles sont nombreux :
+    <ul>
+        <li>Les APIs natives</li>
+        <li>JS côté serveur</li>
+        <li>Les web components</li>
+        <li>Offline et persistence dans le navigateur</li>
+        <li>L'avenir de JavaScript (ES6 notamment)</li>
+        <li>Les outils</li>
+        <li>Les frameworks</li>
+        <li>...</li>
+    </ul>
+  </p>
+  <p>Nous sommes à la recherche de sponsors et de goodies, n'hésitez pas à nous contacter afin de contribuer à faire de cet évènement une réussite !</p>
+  <p>Pour toute question concernant cette conférence, contactez Raphaël Rougeron (@goldoraf / goldoraf chez gmail.com), ou Maxime Thirouin (@MoOx / maxime.thirouin chez gmail.com)</p>
+</article>

--- a/index.html
+++ b/index.html
@@ -13,6 +13,8 @@ title: Communauté française des utilisateurs de JavaScript
 <hr />
 <h2>Quoi de neuf ?</h2>
 <dl>
+    <dt>Jeudi 25 juillet 2013</dt>
+    <dd><a href="conf2013.html" title="Première conf FranceJS à Toulouse">Première conférence FranceJS à Toulouse !</a></dd>
     <dt>Mercredi 13 mars 2013</dt>
     <dd><a href="groupes.html" title="En savoir plus sur les groupes locaux autour de JS">Liste des groupes locaux et leur position</a></dd>
     <dt>Vendredi 8 mars 2013</dt>


### PR DESCRIPTION
Etant donné que l'appel à conférenciers est prêt, il ne nous reste qu'à publier cette page de présentation avant d'annoncer au monde cette première conf ;)
