### PR TITLE
Ajoute BordeauxJS sur la carte

### DIFF
--- a/carte.geojson
+++ b/carte.geojson
@@ -46,7 +46,19 @@
         },
         "geometry": {
             "type": "Point",
-            "coordinates": [2.3508, 48.8567]
+            "coordinates": [1.45534, 43.60218]
+        }
+    },
+    {
+        "type": "Feature",
+        "properties": {
+            "group": "BordeauxJS",
+            "date": "2013-11-07",
+            "url": "http://www.meetup.com/BordeauxJS/"
+        },
+        "geometry": {
+            "type": "Point",
+            "coordinates": [-0.5783, 44.8386]
         }
     }
     ]


### PR DESCRIPTION
Le lieu de BordeauxJS change à chaque session mais ça permet de le rendre visible sur la carte.
